### PR TITLE
Add support for user ip, site key, additional tests and improved example

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*]
 charset = utf-8
-indent_size = 4
+indent_size = 2
 end_of_line = lf
 indent_style = space
 insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ const secret = 'my hcaptcha secret from hcaptcha.com';
 const token = 'token from widget';
 
 verify(secret, token)
-  .then((data) => console.log('success!', data))
+  .then((data) => {
+    if (data.success === true) {
+      console.log('success!', data);
+    } else {
+      console.log('verification failed');
+    }
+  })
   .catch(console.error);
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,8 @@ declare module "hcaptcha" {
    *
    * @param secret HCaptcha secret key (`0x...`)
    * @param token HCaptcha challenge token (`P0_ey...`)
+   * @param remoteip Optional. The user's IP address.
+   * @param sitekey Optional. The sitekey you expect to see.
    */
-  export function verify(secret: string, token: string): Promise<VerifyResponse>;
+  export function verify(secret: string, token: string, remoteip?: string, sitekey?: string): Promise<VerifyResponse>;
 }

--- a/index.js
+++ b/index.js
@@ -7,10 +7,17 @@ const path = '/siteverify';
 // verifies the given token by doing an HTTP POST request
 // to the hcaptcha.com/siteverify endpoint by passing the
 // hCaptcha secret key and token as the payload.
-const verify = (secret, token) => {
+const verify = (secret, token, remoteip, sitekey) => {
   return new Promise(function verifyPromise(resolve, reject) {
+    const payload = {secret: secret, response: token};
+    if (remoteip) {
+      payload.remoteip = remoteip;
+    }
+    if (sitekey) {
+      payload.sitekey = sitekey;
+    }
     // stringify the payload
-    const data = querystring.stringify({secret, response: token});
+    const data = querystring.stringify(payload);
 
     // set up options for the request
     // note that we're using form data here instead of sending JSON

--- a/index.js
+++ b/index.js
@@ -7,9 +7,9 @@ const path = '/siteverify';
 // verifies the given token by doing an HTTP POST request
 // to the hcaptcha.com/siteverify endpoint by passing the
 // hCaptcha secret key and token as the payload.
-const verify = (secret, token, remoteip, sitekey) => {
+const verify = (secret, token, remoteip = null, sitekey = null) => {
   return new Promise(function verifyPromise(resolve, reject) {
-    const payload = {secret: secret, response: token};
+    const payload = {secret, response: token};
     if (remoteip) {
       payload.remoteip = remoteip;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -392,10 +392,10 @@
         "p-locate": "^5.0.0"
       }
     },
-    "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
       "dev": true
     },
     "log-symbols": {
@@ -462,26 +462,15 @@
       "dev": true
     },
     "nock": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-12.0.3.tgz",
-      "integrity": "sha512-QNb/j8kbFnKCiyqi9C5DD0jH/FubFGj5rt9NQFONXwQm3IPB0CULECg/eS3AU1KgZb/6SwUa4/DTRKhVxkGABw==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.1.1.tgz",
+      "integrity": "sha512-YKTR9MjfK3kS9/l4nuTxyYm30cgOExRHzkLNhL8nhEUyU4f8Za/dRxOqjhVT1vGs0svWo3dDnJTUX1qxYeWy5w==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.13",
+        "lodash.set": "^4.3.2",
         "propagate": "^2.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
       }
     },
     "normalize-path": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "^8.2.1",
-    "nock": "^12.0.3"
+    "nock": "^13.1.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -2,83 +2,83 @@
 
 const assert = require('assert');
 const nock = require('nock');
-
-nock.disableNetConnect();
-
 const {verify} = require('../index');
 
+// disable internet access to ensure we are stubbing all reqs
+nock.disableNetConnect();
+
 describe('hCaptcha', function () {
-    describe('verify', function () {
-        const secret = 'secret';
-        const token = 'token';
+  describe('verify', function () {
+    const secret = 'mysecret';
+    const token = 'token';
 
-        it('resolves on success', function (done) {
-            nock('https://hcaptcha.com')
-                .post('/siteverify', 'secret=secret&response=token')
-                .reply(200, '{"success":true}');
-            verify(secret, token)
-                .then((data) => {
-                    assert.deepStrictEqual(data, {success: true});
-                    done();
-                })
-                .catch(done.fail);
-        });
-
-        it('resolves on success with ip', function (done) {
-            nock('https://hcaptcha.com')
-                .post('/siteverify', 'secret=secret&response=token&remoteip=1.3.3.7')
-                .reply(200, '{"success":true}');
-            verify(secret, token, '1.3.3.7')
-                .then((data) => {
-                    assert.deepStrictEqual(data, {success: true});
-                    done();
-                })
-                .catch(done.fail);
-        });
-
-        it('resolves on success with sitekey', function (done) {
-            nock('https://hcaptcha.com')
-                .post('/siteverify', 'secret=secret&response=token&sitekey=mysite')
-                .reply(200, '{"success":true}');
-            verify(secret, token, null, 'mysite')
-                .then((data) => {
-                    assert.deepStrictEqual(data, {success: true});
-                    done();
-                })
-                .catch(done.fail);
-        });
-
-        it('resolves on success with ip and sitekey', function (done) {
-            nock('https://hcaptcha.com')
-                .post('/siteverify', 'secret=secret&response=token&remoteip=1.3.3.7&sitekey=mysite')
-                .reply(200, '{"success":true}');
-            verify(secret, token, '1.3.3.7', 'mysite')
-                .then((data) => {
-                    assert.deepStrictEqual(data, {success: true});
-                    done();
-                })
-                .catch(done.fail);
-        });
-
-        it('resolves on failure', function (done) {
-            nock('https://hcaptcha.com')
-                .post('/siteverify', 'secret=secret&response=token')
-                .reply(200, '{"success":false}');
-            verify(secret, token)
-                .then((data) => {
-                    assert.deepStrictEqual(data, {success: false});
-                    done();
-                })
-                .catch(done.fail);
-        });
-
-        it('throws on http failure', function (done) {
-            nock('https://hcaptcha.com')
-                .post('/siteverify', 'secret=secret&response=token')
-                .replyWithError('failboat');
-            verify(secret, token)
-                .then(done.fail)
-                .catch(() => done())
-        });
+    it('resolves on success', function (done) {
+      nock('https://hcaptcha.com')
+        .post('/siteverify', 'secret=mysecret&response=token')
+        .reply(200, '{"success":true}');
+      verify(secret, token)
+        .then((data) => {
+          assert.deepStrictEqual(data, {success: true});
+          done();
+        })
+        .catch(done.fail);
     });
+
+    it('resolves on success with ip', function (done) {
+      nock('https://hcaptcha.com')
+        .post('/siteverify', 'secret=mysecret&response=token&remoteip=1.3.3.7')
+        .reply(200, '{"success":true}');
+      verify(secret, token, '1.3.3.7')
+        .then((data) => {
+          assert.deepStrictEqual(data, {success: true});
+          done();
+        })
+        .catch(done.fail);
+    });
+
+    it('resolves on success with sitekey', function (done) {
+      nock('https://hcaptcha.com')
+        .post('/siteverify', 'secret=mysecret&response=token&sitekey=mysite')
+        .reply(200, '{"success":true}');
+      verify(secret, token, null, 'mysite')
+        .then((data) => {
+          assert.deepStrictEqual(data, {success: true});
+          done();
+        })
+        .catch(done.fail);
+    });
+
+    it('resolves on success with ip and sitekey', function (done) {
+      nock('https://hcaptcha.com')
+        .post('/siteverify', 'secret=mysecret&response=token&remoteip=1.3.3.7&sitekey=mysite')
+        .reply(200, '{"success":true}');
+      verify(secret, token, '1.3.3.7', 'mysite')
+        .then((data) => {
+          assert.deepStrictEqual(data, {success: true});
+          done();
+        })
+        .catch(done.fail);
+    });
+
+    it('resolves on failure', function (done) {
+      nock('https://hcaptcha.com')
+        .post('/siteverify', 'secret=mysecret&response=token')
+        .reply(200, '{"success":false}');
+      verify(secret, token)
+        .then((data) => {
+          assert.deepStrictEqual(data, {success: false});
+          done();
+        })
+        .catch(done.fail);
+    });
+
+    it('throws on http failure', function (done) {
+      nock('https://hcaptcha.com')
+        .post('/siteverify', 'secret=mysecret&response=token')
+        .replyWithError('failboat');
+      verify(secret, token)
+        .then(done.fail)
+        .catch(() => done())
+    });
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,24 +1,84 @@
+'use strict';
+
 const assert = require('assert');
 const nock = require('nock');
+
+nock.disableNetConnect();
+
 const {verify} = require('../index');
 
-// mock the request
-nock('https://hcaptcha.com')
-  .post('/siteverify', 'secret=secret&response=token')
-  .reply(200, '{"success":true}')
-
 describe('hCaptcha', function () {
-  describe('verify', function () {
-    const secret = 'secret';
-    const token = 'token';
+    describe('verify', function () {
+        const secret = 'secret';
+        const token = 'token';
 
-    it('resolves on success', function (done) {
-      verify(secret, token)
-        .then((data) => {
-          assert.deepStrictEqual(data, {success: true});
-          done();
-        })
-        .catch(done);
+        it('resolves on success', function (done) {
+            nock('https://hcaptcha.com')
+                .post('/siteverify', 'secret=secret&response=token')
+                .reply(200, '{"success":true}');
+            verify(secret, token)
+                .then((data) => {
+                    assert.deepStrictEqual(data, {success: true});
+                    done();
+                })
+                .catch(done.fail);
+        });
+
+        it('resolves on success with ip', function (done) {
+            nock('https://hcaptcha.com')
+                .post('/siteverify', 'secret=secret&response=token&remoteip=1.3.3.7')
+                .reply(200, '{"success":true}');
+            verify(secret, token, '1.3.3.7')
+                .then((data) => {
+                    assert.deepStrictEqual(data, {success: true});
+                    done();
+                })
+                .catch(done.fail);
+        });
+
+        it('resolves on success with sitekey', function (done) {
+            nock('https://hcaptcha.com')
+                .post('/siteverify', 'secret=secret&response=token&sitekey=mysite')
+                .reply(200, '{"success":true}');
+            verify(secret, token, null, 'mysite')
+                .then((data) => {
+                    assert.deepStrictEqual(data, {success: true});
+                    done();
+                })
+                .catch(done.fail);
+        });
+
+        it('resolves on success with ip and sitekey', function (done) {
+            nock('https://hcaptcha.com')
+                .post('/siteverify', 'secret=secret&response=token&remoteip=1.3.3.7&sitekey=mysite')
+                .reply(200, '{"success":true}');
+            verify(secret, token, '1.3.3.7', 'mysite')
+                .then((data) => {
+                    assert.deepStrictEqual(data, {success: true});
+                    done();
+                })
+                .catch(done.fail);
+        });
+
+        it('resolves on failure', function (done) {
+            nock('https://hcaptcha.com')
+                .post('/siteverify', 'secret=secret&response=token')
+                .reply(200, '{"success":false}');
+            verify(secret, token)
+                .then((data) => {
+                    assert.deepStrictEqual(data, {success: false});
+                    done();
+                })
+                .catch(done.fail);
+        });
+
+        it('throws on http failure', function (done) {
+            nock('https://hcaptcha.com')
+                .post('/siteverify', 'secret=secret&response=token')
+                .replyWithError('failboat');
+            verify(secret, token)
+                .then(done.fail)
+                .catch(() => done())
+        });
     });
-  });
 });


### PR DESCRIPTION
Add support for sending user's IP address and site key.
Fix / add tests.
Fix bad example.

fixes https://github.com/vastus/node-hcaptcha/issues/5