### PR TITLE
Replace legacy querystring API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Verify hCaptcha token validity; simply w/ no dependencies.
 
 ## Install
 
-```
+```bash
 npm install --save hcaptcha
 ```
 
 ## Usage
 
 ```js
-const {verify} = require('hcaptcha');
+const { verify } = require('hcaptcha');
 
 const secret = 'my hcaptcha secret from hcaptcha.com';
 const token = 'token from widget';

--- a/index.js
+++ b/index.js
@@ -18,12 +18,15 @@ const stringify = (options = {}) => {
 const verify = (secret, token, remoteip = null, sitekey = null) => {
   return new Promise(function verifyPromise(resolve, reject) {
     const payload = {secret, response: token};
+
     if (remoteip) {
       payload.remoteip = remoteip;
     }
+
     if (sitekey) {
       payload.sitekey = sitekey;
     }
+
     // stringify the payload
     const data = stringify(payload);
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,16 @@
 const https = require('https');
-const querystring = require('querystring');
+const { URLSearchParams } = require('url');
 
 const host = 'hcaptcha.com';
 const path = '/siteverify';
+
+const stringify = (options = {}) => {
+  const params = new URLSearchParams();
+
+  Object.keys(options).forEach((key) => params.append(key, options[key]));
+
+  return params.toString();
+};
 
 // verifies the given token by doing an HTTP POST request
 // to the hcaptcha.com/siteverify endpoint by passing the
@@ -17,7 +25,7 @@ const verify = (secret, token, remoteip = null, sitekey = null) => {
       payload.sitekey = sitekey;
     }
     // stringify the payload
-    const data = querystring.stringify(payload);
+    const data = stringify(payload);
 
     // set up options for the request
     // note that we're using form data here instead of sending JSON


### PR DESCRIPTION
Added a function that simulates legacy querystring.stringify method

Querystring status - [https://nodejs.org/api/querystring.html#query-string](https://nodejs.org/api/querystring.html#query-string)